### PR TITLE
openocd: Use -no-pie as libftdi is compiled with -fPIC

### DIFF
--- a/openocd/build.sh
+++ b/openocd/build.sh
@@ -35,7 +35,7 @@ ldd ./src/openocd
 ls -l ./src/openocd
 du -h ./src/openocd
 echo "---------------------------"
-gcc -Wall -Wstrict-prototypes -Wformat-security -Wshadow -Wextra -Wno-unused-parameter -Wbad-function-cast -Wcast-align -Wredundant-decls -Werror -g -O2 -o src/openocd src/main.o -Wl,-Bstatic src/.libs/libopenocd.a ./jimtcl/libjim.a -lusb-1.0 -lusb -lftdi -Wl,-Bdynamic -Wl,--no-whole-archive -ludev -lpthread -ldl -lm
+gcc -no-pie -Wall -Wstrict-prototypes -Wformat-security -Wshadow -Wextra -Wno-unused-parameter -Wbad-function-cast -Wcast-align -Wredundant-decls -Werror -g -O2 -o src/openocd src/main.o -Wl,-Bstatic src/.libs/libopenocd.a ./jimtcl/libjim.a -lusb-1.0 -lusb -lftdi -Wl,-Bdynamic -Wl,--no-whole-archive -ludev -lpthread -ldl -lm
 ldd ./src/openocd
 ls -l ./src/openocd
 du -h ./src/openocd


### PR DESCRIPTION
Fixes building locally which has the following error;
```
+ gcc -fPIC -Wall -Wstrict-prototypes -Wformat-security -Wshadow -Wextra -Wno-unused-parameter -Wbad-function-cast -Wcast-align -Wredundant-decls -Werror -g -O2 -o src/openocd src/main.o -Wl,-Bstatic src/.libs/libopenocd.a ./jimtcl/libjim.a -lusb-1.0 -lusb -lftdi -Wl,-Bdynamic -Wl,--no-whole-archive -ludev -lpthread -ldl -lm
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/7/../../../x86_64-linux-gnu/libftdi.a(ftdi.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
/usr/bin/ld: final link failed: Nonrepresentable section on output
```

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>