### PR TITLE
Build a Linux + musl toolchain using musl-cross-make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,14 @@ jobs:
      env:
      - PACKAGE=libftdi
 
+   # musl toolchain...
+   - stage: "Toolchain - Linux MUSL"
+     env:
+     - PACKAGE=toolchain/linux-musl TOOLCHAIN_ARCH=or1k
+   - stage: "Toolchain - Linux MUSL"
+     env:
+     - PACKAGE=toolchain/linux-musl TOOLCHAIN_ARCH=riscv32
+
    # lm32 toolchain
    - stage: "Binutils"
      env:

--- a/toolchain/linux-musl/build.sh
+++ b/toolchain/linux-musl/build.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# gcc newlib build
+set -e
+
+if [ -z "${TOOLCHAIN_ARCH}" ]; then
+	export | grep -i toolchain
+	echo "Missing \${TOOLCHAIN_ARCH} env value"
+	exit 1
+else
+	echo "TOOLCHAIN_ARCH: '$TOOLCHAIN_ARCH'"
+fi
+if [ x"$PKG_VERSION" = x ]; then
+	export | grep version
+	export | grep VERSION
+	exit 1
+else
+	echo "PKG_VERSION: '$PKG_VERSION'"
+fi
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+echo
+echo
+echo "============================================================"
+echo "CFLAGS='$CFLAGS'"
+echo "CXXFLAGS='$CXXFLAGS'"
+echo "CPPFLAGS='$CPPFLAGS'"
+echo "DEBUG_CXXFLAGS='$DEBUG_CXXFLAGS'"
+echo "DEBUG_CPPFLAGS='$DEBUG_CPPFLAGS'"
+echo "LDFLAGS='$LDFLAGS'"
+echo "------------------------------------------------------------"
+export CFLAGS="$(echo $CFLAGS) -w"
+export CXXFLAGS="$(echo $CXXFLAGS | sed -e's/-std=c++17 //') -w"
+export CPPFLAGS="$(echo $CPPFLAGS | sed -e's/-std=c++17 //')"
+export DEBUG_CXXFLAGS="$(echo $DEBUG_CXXFLAGS | sed -e's/-std=c++17 //') -w"
+export DEBUG_CPPFLAGS="$(echo $DEBUG_CPPFLAGS | sed -e's/-std=c++17 //')"
+echo "CFLAGS='$CFLAGS'"
+echo "CXXFLAGS='$CXXFLAGS'"
+echo "CPPFLAGS='$CPPFLAGS'"
+echo "DEBUG_CXXFLAGS='$DEBUG_CXXFLAGS'"
+echo "DEBUG_CPPFLAGS='$DEBUG_CPPFLAGS'"
+echo "LDFLAGS='$LDFLAGS'"
+echo "------------------------------------------------------------"
+export
+echo "============================================================"
+echo
+echo
+echo "Start directory ============================================"
+echo $PWD
+ls -l $PWD
+echo "------------------------------------------------------------"
+ls -l $PWD/*
+echo "============================================================"
+echo
+echo
+echo "Source directory ==========================================="
+echo $SRC_DIR
+ls -l $SRC_DIR
+echo "------------------------------------------------------------"
+ls -l $SRC_DIR/*
+echo "============================================================"
+echo
+echo
+
+cat > config.mak <<EOF
+TARGET=${TOOLCHAIN_ARCH}-linux-musl
+OUTPUT=${PREFIX}
+BINUTILS_VER=${binutils_version}
+GCC_VER=${gcc_version}
+MUSL_VER=${musl_version}
+LINUX_VER=${linux_version}
+
+GCC_CONFIG += --enable-languages=c
+
+MUSL_CONFIG += CFLAGS="" CPPFLAGS="" DEBUG_CPPFLAGS="" CXXFLAGS="" DEBUG_CXXFLAGS="" LDFLAGS=""
+
+EOF
+echo "============================================================"
+cat config.mak
+echo "============================================================"
+
+make -j$CPU_COUNT
+make install
+rm $PREFIX/$TOOLCHAIN_ARCH-linux-musl/lib/ld-musl-$TOOLCHAIN_ARCH.so.1
+ln -sf $PREFIX/$TOOLCHAIN_ARCH-linux-musl/lib/libc.so $PREFIX/$TOOLCHAIN_ARCH-linux-musl/lib/ld-musl-$TOOLCHAIN_ARCH.so.1

--- a/toolchain/linux-musl/conda_build_config.yaml
+++ b/toolchain/linux-musl/conda_build_config.yaml
@@ -1,0 +1,8 @@
+binutils_version:
+ - 2.32
+gcc_version:
+ - 9.1.0
+musl_version:
+ -  git-ac304227bb3ea1787d581f17d76a5f5f3abff51f
+linux_version:
+ - 4.19.44

--- a/toolchain/linux-musl/meta.yaml
+++ b/toolchain/linux-musl/meta.yaml
@@ -1,0 +1,40 @@
+package:
+  name: toolchain-{{ environ.get('TOOLCHAIN_ARCH') }}-linux-musl
+  version: {{ environ.get('GITREV').replace('-', '_') }}
+
+source:
+  - git_url: https://git.zv.io/toolchains/musl-cross-make.git
+    git_rev: musl-git
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+    - TOOLCHAIN_ARCH
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    # These are taken from the output of the configure scripts
+    - gmp >=4.3.2
+    - mpfr >=2.4.2
+    - mpc >=0.8.1
+    - isl >=0.15.0
+    - cloog
+
+about:
+  home: https://gcc.gnu.org/
+  license: GPL
+  summary: 'The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, Ada, and Go, as well as libraries for these languages (libstdc++, libgcj,...).'
+
+extra:
+  gcc_version: {{ gcc_version }}
+  binutils_version: {{ binutils_version }}
+  musl_version: {{ musl_version }}
+  linux_version: {{ linux_version }}

--- a/toolchain/linux-musl/run_test.sh
+++ b/toolchain/linux-musl/run_test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# gcc linux-musl run test
+
+TARGET=${TOOLCHAIN_ARCH}-linux-musl
+GCC=$TARGET-gcc
+OBJDUMP=$TARGET-objdump
+
+set -x
+set -e
+
+echo "============================="
+echo "============================="
+echo "============================="
+echo "============================="
+$GCC --help || true
+echo "-----"
+$GCC --version || true
+echo "-----"
+$GCC -dumpspecs || true
+echo "-----"
+$GCC -dumpversion || true
+echo "-----"
+$GCC -dumpmachine || true
+echo "-----"
+$GCC -print-search-dirs || true
+echo "-----"
+$GCC -print-libgcc-file-name || true
+echo "-----"
+$GCC -print-file-name=m || true
+echo "-----"
+$GCC -print-prog-name=as || true
+echo "-----"
+$GCC -print-multiarch || true
+echo "-----"
+$GCC -print-multi-directory || true
+echo "-----"
+$GCC -print-multi-lib || true
+echo "-----"
+$GCC -print-multi-os-directory || true
+echo "-----"
+$GCC -print-sysroot || true
+echo "-----"
+$GCC -print-sysroot-headers-suffix || true
+echo "============================="
+echo "============================="
+echo "============================="
+echo "============================="
+
+set +x
+set +e
+
+
+if [ "${TOOLCHAIN_ARCH}" = "riscv32" ]; then
+	ELF_ARCH="riscv:rv32"
+else
+	ELF_ARCH="${TOOLCHAIN_ARCH}"
+fi
+
+# Check the compiler can build a simple C app which requires the standard
+# library.
+echo "==========================================="
+set -x
+$GCC -v --version
+$GCC -v --target-help
+$GCC -v -dumpspecs
+$GCC -v -dumpversion
+$GCC -v -dumpmachine
+$GCC -v -print-search-dirs
+$GCC -v -print-libgcc-file-name
+$GCC -v -print-multiarch
+$GCC -v -print-multi-directory
+$GCC -v -print-multi-lib
+$GCC -v -print-multi-os-directory
+$GCC -v -print-sysroot
+$GCC -print-sysroot-headers-suffix
+#$TARGET-cpp -Wp,-v
+echo "==========================================="
+
+echo "Compile and link a 'bare metal' binary with stdlib"
+
+cat > main.c <<EOF
+#include <stdio.h>
+int main() {
+	puts("Hello world!\n");
+}
+EOF
+
+echo "Compiling main"
+$GCC -v -g main.c -o main -Wl,-Map=output.map
+SUCCESS=$?
+if [ $SUCCESS -ne 0 ]; then
+	echo "Compiler didn't exit successfully."
+	exit 1
+fi
+
+if [ ! -e main ]; then
+	echo "Compiler didn't make a binary output file!"
+	exit 1
+fi
+
+file main
+echo
+echo "output.map"
+echo "-------------------------------------------"
+cat output.map \
+	| sed -e's-[^ ]\+/bin/-[BIN]/-g' -e's-[^ ]\+/work/-[WORK]/-g'
+echo "-------------------------------------------"
+echo
+
+$TARGET-objdump -f ./main
+if ! $TARGET-objdump -f ./main | grep -q "architecture: ${ELF_ARCH}"; then
+	echo "Compiled binary output not correct architecture!"
+	exit 1
+fi
+
+$TARGET-objdump -g ./main 2>&1 \
+	| grep libc \
+	| sed -e's-[^ ]\+/bin/-[BIN]/-g' -e's-[^ ]\+/work/-[WORK]/-g'
+SUCCESS=$?
+if [ $SUCCESS -ne 0 ]; then
+	echo "Compiled binary not linked against musl libc!"
+	exit 1
+fi


### PR DESCRIPTION
 * Upstream musl doesn't have riscv32 support yet.
 * The toolchains at [musl.cc](https://musl.cc) have a or1k + riscv32 toolchain.
 * It is built [using zv.io's fork of musl-cross-make](https://git.zv.io/toolchains/musl-cross-make/tree/musl-git)
 * This is a temporary solution until we figure out musl with riscv32 a better way.