### PR TITLE
Enabling stage 2 gcc for new architectures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,15 +62,15 @@ jobs:
    - stage: "GCC - nostdc"
      env:
      - PACKAGE=gcc/nostdc   TOOLCHAIN_ARCH=riscv64
-#   - stage: "GCC - newlib"
-#     env:
-#     - PACKAGE=gcc/newlib   TOOLCHAIN_ARCH=riscv64
+   - stage: "GCC - newlib"
+     env:
+     - PACKAGE=gcc/newlib   TOOLCHAIN_ARCH=riscv64
    - stage: "GCC - Linux (musl)"
      env:
      - PACKAGE=gcc/linux-musl TOOLCHAIN_ARCH=riscv64
-#   - stage: "GDB"
-#     env:
-#     - PACKAGE=gdb          TOOLCHAIN_ARCH=riscv64
+   - stage: "GDB"
+     env:
+     - PACKAGE=gdb          TOOLCHAIN_ARCH=riscv64
 
    # lm32 toolchain - no linux
    - stage: "Binutils"


### PR DESCRIPTION
Now binutils + stage 1 GCC has landed, enable newlib + gdb builds for these new architectures.
